### PR TITLE
Improve theme handling with system preference support

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+registry=https://registry.npmjs.org/

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,16 +25,18 @@
     },
     "node_modules/@next/env": {
       "version": "14.2.33",
-      "resolved": "https://bendingspoons.jfrog.io/bendingspoons/api/npm/npm/@next/env/-/env-14.2.33.tgz",
-      "integrity": "sha512-CgVHNZ1fRIlxkLhIX22flAZI/HmpDaZ8vwyJ/B0SDPTBuLZ1PJ+DWMjCHhqnExfmSQzA/PbZi8OAc7PAq2w9IA=="
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.33.tgz",
+      "integrity": "sha512-CgVHNZ1fRIlxkLhIX22flAZI/HmpDaZ8vwyJ/B0SDPTBuLZ1PJ+DWMjCHhqnExfmSQzA/PbZi8OAc7PAq2w9IA==",
+      "license": "MIT"
     },
     "node_modules/@next/swc-darwin-arm64": {
       "version": "14.2.33",
-      "resolved": "https://bendingspoons.jfrog.io/bendingspoons/api/npm/npm/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.2.33.tgz",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.2.33.tgz",
       "integrity": "sha512-HqYnb6pxlsshoSTubdXKu15g3iivcbsMXg4bYpjL2iS/V6aQot+iyF4BUc2qA/J/n55YtvE4PHMKWBKGCF/+wA==",
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -45,11 +47,12 @@
     },
     "node_modules/@next/swc-darwin-x64": {
       "version": "14.2.33",
-      "resolved": "https://bendingspoons.jfrog.io/bendingspoons/api/npm/npm/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.33.tgz",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.33.tgz",
       "integrity": "sha512-8HGBeAE5rX3jzKvF593XTTFg3gxeU4f+UWnswa6JPhzaR6+zblO5+fjltJWIZc4aUalqTclvN2QtTC37LxvZAA==",
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -60,11 +63,12 @@
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
       "version": "14.2.33",
-      "resolved": "https://bendingspoons.jfrog.io/bendingspoons/api/npm/npm/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.33.tgz",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.33.tgz",
       "integrity": "sha512-JXMBka6lNNmqbkvcTtaX8Gu5by9547bukHQvPoLe9VRBx1gHwzf5tdt4AaezW85HAB3pikcvyqBToRTDA4DeLw==",
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -75,11 +79,12 @@
     },
     "node_modules/@next/swc-linux-arm64-musl": {
       "version": "14.2.33",
-      "resolved": "https://bendingspoons.jfrog.io/bendingspoons/api/npm/npm/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.33.tgz",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.33.tgz",
       "integrity": "sha512-Bm+QulsAItD/x6Ih8wGIMfRJy4G73tu1HJsrccPW6AfqdZd0Sfm5Imhgkgq2+kly065rYMnCOxTBvmvFY1BKfg==",
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -90,11 +95,12 @@
     },
     "node_modules/@next/swc-linux-x64-gnu": {
       "version": "14.2.33",
-      "resolved": "https://bendingspoons.jfrog.io/bendingspoons/api/npm/npm/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.33.tgz",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.33.tgz",
       "integrity": "sha512-FnFn+ZBgsVMbGDsTqo8zsnRzydvsGV8vfiWwUo1LD8FTmPTdV+otGSWKc4LJec0oSexFnCYVO4hX8P8qQKaSlg==",
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -105,11 +111,12 @@
     },
     "node_modules/@next/swc-linux-x64-musl": {
       "version": "14.2.33",
-      "resolved": "https://bendingspoons.jfrog.io/bendingspoons/api/npm/npm/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.33.tgz",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.33.tgz",
       "integrity": "sha512-345tsIWMzoXaQndUTDv1qypDRiebFxGYx9pYkhwY4hBRaOLt8UGfiWKr9FSSHs25dFIf8ZqIFaPdy5MljdoawA==",
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -120,11 +127,12 @@
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
       "version": "14.2.33",
-      "resolved": "https://bendingspoons.jfrog.io/bendingspoons/api/npm/npm/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.33.tgz",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.33.tgz",
       "integrity": "sha512-nscpt0G6UCTkrT2ppnJnFsYbPDQwmum4GNXYTeoTIdsmMydSKFz9Iny2jpaRupTb+Wl298+Rh82WKzt9LCcqSQ==",
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -135,11 +143,12 @@
     },
     "node_modules/@next/swc-win32-ia32-msvc": {
       "version": "14.2.33",
-      "resolved": "https://bendingspoons.jfrog.io/bendingspoons/api/npm/npm/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.33.tgz",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.33.tgz",
       "integrity": "sha512-pc9LpGNKhJ0dXQhZ5QMmYxtARwwmWLpeocFmVG5Z0DzWq5Uf0izcI8tLc+qOpqxO1PWqZ5A7J1blrUIKrIFc7Q==",
       "cpu": [
         "ia32"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -150,11 +159,12 @@
     },
     "node_modules/@next/swc-win32-x64-msvc": {
       "version": "14.2.33",
-      "resolved": "https://bendingspoons.jfrog.io/bendingspoons/api/npm/npm/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.33.tgz",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.33.tgz",
       "integrity": "sha512-nOjfZMy8B94MdisuzZo9/57xuFVLHJaDj5e/xrduJp9CV2/HrfxTRH2fbyLe+K9QT41WBLUd4iXX3R7jBp0EUg==",
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -165,10 +175,11 @@
     },
     "node_modules/@parcel/watcher": {
       "version": "2.5.1",
-      "resolved": "https://bendingspoons.jfrog.io/bendingspoons/api/npm/npm/@parcel/watcher/-/watcher-2.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.1.tgz",
       "integrity": "sha512-dfUnCxiN9H4ap84DvD2ubjw+3vUNpstxa0TneY/Paat8a3R4uQZDLSvWjmznAY/DoahqTHl9V46HF/Zs3F29pg==",
       "dev": true,
       "hasInstallScript": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "detect-libc": "^1.0.3",
@@ -201,12 +212,13 @@
     },
     "node_modules/@parcel/watcher-android-arm64": {
       "version": "2.5.1",
-      "resolved": "https://bendingspoons.jfrog.io/bendingspoons/api/npm/npm/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.5.1.tgz",
       "integrity": "sha512-KF8+j9nNbUN8vzOFDpRMsaKBHZ/mcjEjMToVMJOhTozkDonQFFrRcfdLWn6yWKCmJKmdVxSgHiYvTCef4/qcBA==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "android"
@@ -221,12 +233,13 @@
     },
     "node_modules/@parcel/watcher-darwin-arm64": {
       "version": "2.5.1",
-      "resolved": "https://bendingspoons.jfrog.io/bendingspoons/api/npm/npm/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.5.1.tgz",
       "integrity": "sha512-eAzPv5osDmZyBhou8PoF4i6RQXAfeKL9tjb3QzYuccXFMQU0ruIc/POh30ePnaOyD1UXdlKguHBmsTs53tVoPw==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -241,12 +254,13 @@
     },
     "node_modules/@parcel/watcher-darwin-x64": {
       "version": "2.5.1",
-      "resolved": "https://bendingspoons.jfrog.io/bendingspoons/api/npm/npm/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.5.1.tgz",
       "integrity": "sha512-1ZXDthrnNmwv10A0/3AJNZ9JGlzrF82i3gNQcWOzd7nJ8aj+ILyW1MTxVk35Db0u91oD5Nlk9MBiujMlwmeXZg==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -261,12 +275,13 @@
     },
     "node_modules/@parcel/watcher-freebsd-x64": {
       "version": "2.5.1",
-      "resolved": "https://bendingspoons.jfrog.io/bendingspoons/api/npm/npm/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.5.1.tgz",
       "integrity": "sha512-SI4eljM7Flp9yPuKi8W0ird8TI/JK6CSxju3NojVI6BjHsTyK7zxA9urjVjEKJ5MBYC+bLmMcbAWlZ+rFkLpJQ==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "freebsd"
@@ -281,12 +296,13 @@
     },
     "node_modules/@parcel/watcher-linux-arm-glibc": {
       "version": "2.5.1",
-      "resolved": "https://bendingspoons.jfrog.io/bendingspoons/api/npm/npm/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.5.1.tgz",
       "integrity": "sha512-RCdZlEyTs8geyBkkcnPWvtXLY44BCeZKmGYRtSgtwwnHR4dxfHRG3gR99XdMEdQ7KeiDdasJwwvNSF5jKtDwdA==",
       "cpu": [
         "arm"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -301,12 +317,13 @@
     },
     "node_modules/@parcel/watcher-linux-arm-musl": {
       "version": "2.5.1",
-      "resolved": "https://bendingspoons.jfrog.io/bendingspoons/api/npm/npm/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.5.1.tgz",
       "integrity": "sha512-6E+m/Mm1t1yhB8X412stiKFG3XykmgdIOqhjWj+VL8oHkKABfu/gjFj8DvLrYVHSBNC+/u5PeNrujiSQ1zwd1Q==",
       "cpu": [
         "arm"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -321,12 +338,13 @@
     },
     "node_modules/@parcel/watcher-linux-arm64-glibc": {
       "version": "2.5.1",
-      "resolved": "https://bendingspoons.jfrog.io/bendingspoons/api/npm/npm/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.5.1.tgz",
       "integrity": "sha512-LrGp+f02yU3BN9A+DGuY3v3bmnFUggAITBGriZHUREfNEzZh/GO06FF5u2kx8x+GBEUYfyTGamol4j3m9ANe8w==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -341,12 +359,13 @@
     },
     "node_modules/@parcel/watcher-linux-arm64-musl": {
       "version": "2.5.1",
-      "resolved": "https://bendingspoons.jfrog.io/bendingspoons/api/npm/npm/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.5.1.tgz",
       "integrity": "sha512-cFOjABi92pMYRXS7AcQv9/M1YuKRw8SZniCDw0ssQb/noPkRzA+HBDkwmyOJYp5wXcsTrhxO0zq1U11cK9jsFg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -361,12 +380,13 @@
     },
     "node_modules/@parcel/watcher-linux-x64-glibc": {
       "version": "2.5.1",
-      "resolved": "https://bendingspoons.jfrog.io/bendingspoons/api/npm/npm/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.5.1.tgz",
       "integrity": "sha512-GcESn8NZySmfwlTsIur+49yDqSny2IhPeZfXunQi48DMugKeZ7uy1FX83pO0X22sHntJ4Ub+9k34XQCX+oHt2A==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -381,12 +401,13 @@
     },
     "node_modules/@parcel/watcher-linux-x64-musl": {
       "version": "2.5.1",
-      "resolved": "https://bendingspoons.jfrog.io/bendingspoons/api/npm/npm/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.5.1.tgz",
       "integrity": "sha512-n0E2EQbatQ3bXhcH2D1XIAANAcTZkQICBPVaxMeaCVBtOpBZpWJuf7LwyWPSBDITb7In8mqQgJ7gH8CILCURXg==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -401,12 +422,13 @@
     },
     "node_modules/@parcel/watcher-win32-arm64": {
       "version": "2.5.1",
-      "resolved": "https://bendingspoons.jfrog.io/bendingspoons/api/npm/npm/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.5.1.tgz",
       "integrity": "sha512-RFzklRvmc3PkjKjry3hLF9wD7ppR4AKcWNzH7kXR7GUe0Igb3Nz8fyPwtZCSquGrhU5HhUNDr/mKBqj7tqA2Vw==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -421,12 +443,13 @@
     },
     "node_modules/@parcel/watcher-win32-ia32": {
       "version": "2.5.1",
-      "resolved": "https://bendingspoons.jfrog.io/bendingspoons/api/npm/npm/@parcel/watcher-win32-ia32/-/watcher-win32-ia32-2.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-ia32/-/watcher-win32-ia32-2.5.1.tgz",
       "integrity": "sha512-c2KkcVN+NJmuA7CGlaGD1qJh1cLfDnQsHjE89E60vUEMlqduHGCdCLJCID5geFVM0dOtA3ZiIO8BoEQmzQVfpQ==",
       "cpu": [
         "ia32"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -441,12 +464,13 @@
     },
     "node_modules/@parcel/watcher-win32-x64": {
       "version": "2.5.1",
-      "resolved": "https://bendingspoons.jfrog.io/bendingspoons/api/npm/npm/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.5.1.tgz",
       "integrity": "sha512-9lHBdJITeNR++EvSQVUcaZoWupyHfXe1jZvGZ06O/5MflPcuPLtEphScIBL+AiCWBO46tDSHzWyD0uDmmZqsgA==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -461,13 +485,15 @@
     },
     "node_modules/@swc/counter": {
       "version": "0.1.3",
-      "resolved": "https://bendingspoons.jfrog.io/bendingspoons/api/npm/npm/@swc/counter/-/counter-0.1.3.tgz",
-      "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ=="
+      "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
+      "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
+      "license": "Apache-2.0"
     },
     "node_modules/@swc/helpers": {
       "version": "0.5.5",
-      "resolved": "https://bendingspoons.jfrog.io/bendingspoons/api/npm/npm/@swc/helpers/-/helpers-0.5.5.tgz",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.5.tgz",
       "integrity": "sha512-KGYxvIOXcceOAbEk4bi/dVLEK9z8sZ0uBB3Il5b1rhfClSpcX0yfRO0KmTkqR2cnQDymwLB+25ZyMzICg/cm/A==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@swc/counter": "^0.1.3",
         "tslib": "^2.4.0"
@@ -475,30 +501,34 @@
     },
     "node_modules/@types/aos": {
       "version": "3.0.7",
-      "resolved": "https://bendingspoons.jfrog.io/bendingspoons/api/npm/npm/@types/aos/-/aos-3.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/@types/aos/-/aos-3.0.7.tgz",
       "integrity": "sha512-sEhyFqvKauUJZDbvAB3Pggynrq6g+2PS4XB3tmUr+mDL1gfDJnwslUC4QQ7/l8UD+LWpr3RxZVR/rHoZrLqZVg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "20.19.25",
-      "resolved": "https://bendingspoons.jfrog.io/bendingspoons/api/npm/npm/@types/node/-/node-20.19.25.tgz",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.25.tgz",
       "integrity": "sha512-ZsJzA5thDQMSQO788d7IocwwQbI8B5OPzmqNvpf3NY/+MHDAS759Wo0gd2WQeXYt5AAAQjzcrTVC6SKCuYgoCQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
       }
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.15",
-      "resolved": "https://bendingspoons.jfrog.io/bendingspoons/api/npm/npm/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "18.3.27",
-      "resolved": "https://bendingspoons.jfrog.io/bendingspoons/api/npm/npm/@types/react/-/react-18.3.27.tgz",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.27.tgz",
       "integrity": "sha512-cisd7gxkzjBKU2GgdYrTdtQx1SORymWyaAFhaxQPK9bYO9ot3Y5OikQRvY0VYQtvwjeQnizCINJAenh/V7MK2w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -506,17 +536,19 @@
     },
     "node_modules/@types/react-dom": {
       "version": "18.3.7",
-      "resolved": "https://bendingspoons.jfrog.io/bendingspoons/api/npm/npm/@types/react-dom/-/react-dom-18.3.7.tgz",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
       "dev": true,
+      "license": "MIT",
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
     },
     "node_modules/aos": {
       "version": "2.3.4",
-      "resolved": "https://bendingspoons.jfrog.io/bendingspoons/api/npm/npm/aos/-/aos-2.3.4.tgz",
+      "resolved": "https://registry.npmjs.org/aos/-/aos-2.3.4.tgz",
       "integrity": "sha512-zh/ahtR2yME4I51z8IttIt4lC1Nw0ktsFtmeDzID1m9naJnWXhCoARaCgNOGXb5CLy3zm+wqmRAEgMYB5E2HUw==",
+      "license": "MIT",
       "dependencies": {
         "classlist-polyfill": "^1.0.3",
         "lodash.debounce": "^4.0.6",
@@ -525,9 +557,10 @@
     },
     "node_modules/braces": {
       "version": "3.0.3",
-      "resolved": "https://bendingspoons.jfrog.io/bendingspoons/api/npm/npm/braces/-/braces-3.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "fill-range": "^7.1.1"
@@ -538,7 +571,7 @@
     },
     "node_modules/busboy": {
       "version": "1.6.0",
-      "resolved": "https://bendingspoons.jfrog.io/bendingspoons/api/npm/npm/busboy/-/busboy-1.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
       "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
       "dependencies": {
         "streamsearch": "^1.1.0"
@@ -549,7 +582,7 @@
     },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001759",
-      "resolved": "https://bendingspoons.jfrog.io/bendingspoons/api/npm/npm/caniuse-lite/-/caniuse-lite-1.0.30001759.tgz",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001759.tgz",
       "integrity": "sha512-Pzfx9fOKoKvevQf8oCXoyNRQ5QyxJj+3O0Rqx2V5oxT61KGx8+n6hV/IUyJeifUci2clnmmKVpvtiqRzgiWjSw==",
       "funding": [
         {
@@ -564,13 +597,15 @@
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
-      ]
+      ],
+      "license": "CC-BY-4.0"
     },
     "node_modules/chokidar": {
       "version": "4.0.3",
-      "resolved": "https://bendingspoons.jfrog.io/bendingspoons/api/npm/npm/chokidar/-/chokidar-4.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
       "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
       "devOptional": true,
+      "license": "MIT",
       "dependencies": {
         "readdirp": "^4.0.1"
       },
@@ -583,25 +618,29 @@
     },
     "node_modules/classlist-polyfill": {
       "version": "1.2.0",
-      "resolved": "https://bendingspoons.jfrog.io/bendingspoons/api/npm/npm/classlist-polyfill/-/classlist-polyfill-1.2.0.tgz",
-      "integrity": "sha512-GzIjNdcEtH4ieA2S8NmrSxv7DfEV5fmixQeyTmqmRmRJPGpRBaSnA2a0VrCjyT8iW8JjEdMbKzDotAJf+ajgaQ=="
+      "resolved": "https://registry.npmjs.org/classlist-polyfill/-/classlist-polyfill-1.2.0.tgz",
+      "integrity": "sha512-GzIjNdcEtH4ieA2S8NmrSxv7DfEV5fmixQeyTmqmRmRJPGpRBaSnA2a0VrCjyT8iW8JjEdMbKzDotAJf+ajgaQ==",
+      "license": "Unlicense"
     },
     "node_modules/client-only": {
       "version": "0.0.1",
-      "resolved": "https://bendingspoons.jfrog.io/bendingspoons/api/npm/npm/client-only/-/client-only-0.0.1.tgz",
-      "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA=="
+      "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
+      "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
+      "license": "MIT"
     },
     "node_modules/csstype": {
       "version": "3.2.3",
-      "resolved": "https://bendingspoons.jfrog.io/bendingspoons/api/npm/npm/csstype/-/csstype-3.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/detect-libc": {
       "version": "1.0.3",
-      "resolved": "https://bendingspoons.jfrog.io/bendingspoons/api/npm/npm/detect-libc/-/detect-libc-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
       "integrity": "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==",
       "dev": true,
+      "license": "Apache-2.0",
       "optional": true,
       "bin": {
         "detect-libc": "bin/detect-libc.js"
@@ -612,9 +651,10 @@
     },
     "node_modules/fill-range": {
       "version": "7.1.1",
-      "resolved": "https://bendingspoons.jfrog.io/bendingspoons/api/npm/npm/fill-range/-/fill-range-7.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
       "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -625,20 +665,23 @@
     },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
-      "resolved": "https://bendingspoons.jfrog.io/bendingspoons/api/npm/npm/graceful-fs/-/graceful-fs-4.2.11.tgz",
-      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "license": "ISC"
     },
     "node_modules/immutable": {
       "version": "5.1.4",
-      "resolved": "https://bendingspoons.jfrog.io/bendingspoons/api/npm/npm/immutable/-/immutable-5.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.4.tgz",
       "integrity": "sha512-p6u1bG3YSnINT5RQmx/yRZBpenIl30kVxkTLDyHLIMk0gict704Q9n+thfDI7lTRm9vXdDYutVzXhzcThxTnXA==",
-      "devOptional": true
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
-      "resolved": "https://bendingspoons.jfrog.io/bendingspoons/api/npm/npm/is-extglob/-/is-extglob-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "engines": {
         "node": ">=0.10.0"
@@ -646,9 +689,10 @@
     },
     "node_modules/is-glob": {
       "version": "4.0.3",
-      "resolved": "https://bendingspoons.jfrog.io/bendingspoons/api/npm/npm/is-glob/-/is-glob-4.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -659,9 +703,10 @@
     },
     "node_modules/is-number": {
       "version": "7.0.0",
-      "resolved": "https://bendingspoons.jfrog.io/bendingspoons/api/npm/npm/is-number/-/is-number-7.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "engines": {
         "node": ">=0.12.0"
@@ -669,23 +714,27 @@
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
-      "resolved": "https://bendingspoons.jfrog.io/bendingspoons/api/npm/npm/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
     },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
-      "resolved": "https://bendingspoons.jfrog.io/bendingspoons/api/npm/npm/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
-      "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow=="
+      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+      "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
+      "license": "MIT"
     },
     "node_modules/lodash.throttle": {
       "version": "4.1.1",
-      "resolved": "https://bendingspoons.jfrog.io/bendingspoons/api/npm/npm/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
-      "integrity": "sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ=="
+      "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
+      "integrity": "sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ==",
+      "license": "MIT"
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
-      "resolved": "https://bendingspoons.jfrog.io/bendingspoons/api/npm/npm/loose-envify/-/loose-envify-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       },
@@ -695,9 +744,10 @@
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
-      "resolved": "https://bendingspoons.jfrog.io/bendingspoons/api/npm/npm/micromatch/-/micromatch-4.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
       "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "braces": "^3.0.3",
@@ -709,7 +759,7 @@
     },
     "node_modules/nanoid": {
       "version": "3.3.11",
-      "resolved": "https://bendingspoons.jfrog.io/bendingspoons/api/npm/npm/nanoid/-/nanoid-3.3.11.tgz",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
       "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
       "funding": [
         {
@@ -717,6 +767,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -726,8 +777,9 @@
     },
     "node_modules/next": {
       "version": "14.2.33",
-      "resolved": "https://bendingspoons.jfrog.io/bendingspoons/api/npm/npm/next/-/next-14.2.33.tgz",
+      "resolved": "https://registry.npmjs.org/next/-/next-14.2.33.tgz",
       "integrity": "sha512-GiKHLsD00t4ACm1p00VgrI0rUFAC9cRDGReKyERlM57aeEZkOQGcZTpIbsGn0b562FTPJWmYfKwplfO9EaT6ng==",
+      "license": "MIT",
       "dependencies": {
         "@next/env": "14.2.33",
         "@swc/helpers": "0.5.5",
@@ -775,21 +827,24 @@
     },
     "node_modules/node-addon-api": {
       "version": "7.1.1",
-      "resolved": "https://bendingspoons.jfrog.io/bendingspoons/api/npm/npm/node-addon-api/-/node-addon-api-7.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
       "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
       "dev": true,
+      "license": "MIT",
       "optional": true
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
-      "resolved": "https://bendingspoons.jfrog.io/bendingspoons/api/npm/npm/picocolors/-/picocolors-1.1.1.tgz",
-      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
-      "resolved": "https://bendingspoons.jfrog.io/bendingspoons/api/npm/npm/picomatch/-/picomatch-2.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "engines": {
         "node": ">=8.6"
@@ -800,7 +855,7 @@
     },
     "node_modules/postcss": {
       "version": "8.4.31",
-      "resolved": "https://bendingspoons.jfrog.io/bendingspoons/api/npm/npm/postcss/-/postcss-8.4.31.tgz",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
       "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
       "funding": [
         {
@@ -816,6 +871,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "nanoid": "^3.3.6",
         "picocolors": "^1.0.0",
@@ -827,8 +883,9 @@
     },
     "node_modules/react": {
       "version": "18.3.1",
-      "resolved": "https://bendingspoons.jfrog.io/bendingspoons/api/npm/npm/react/-/react-18.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -838,8 +895,9 @@
     },
     "node_modules/react-dom": {
       "version": "18.3.1",
-      "resolved": "https://bendingspoons.jfrog.io/bendingspoons/api/npm/npm/react-dom/-/react-dom-18.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -850,9 +908,10 @@
     },
     "node_modules/readdirp": {
       "version": "4.1.2",
-      "resolved": "https://bendingspoons.jfrog.io/bendingspoons/api/npm/npm/readdirp/-/readdirp-4.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
       "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
       "devOptional": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 14.18.0"
       },
@@ -863,9 +922,10 @@
     },
     "node_modules/sass": {
       "version": "1.94.2",
-      "resolved": "https://bendingspoons.jfrog.io/bendingspoons/api/npm/npm/sass/-/sass-1.94.2.tgz",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.94.2.tgz",
       "integrity": "sha512-N+7WK20/wOr7CzA2snJcUSSNTCzeCGUTFY3OgeQP3mZ1aj9NMQ0mSTXwlrnd89j33zzQJGqIN52GIOmYrfq46A==",
       "devOptional": true,
+      "license": "MIT",
       "dependencies": {
         "chokidar": "^4.0.0",
         "immutable": "^5.0.2",
@@ -883,23 +943,25 @@
     },
     "node_modules/scheduler": {
       "version": "0.23.2",
-      "resolved": "https://bendingspoons.jfrog.io/bendingspoons/api/npm/npm/scheduler/-/scheduler-0.23.2.tgz",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
       "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0"
       }
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",
-      "resolved": "https://bendingspoons.jfrog.io/bendingspoons/api/npm/npm/source-map-js/-/source-map-js-1.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/streamsearch": {
       "version": "1.1.0",
-      "resolved": "https://bendingspoons.jfrog.io/bendingspoons/api/npm/npm/streamsearch/-/streamsearch-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
       "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
       "engines": {
         "node": ">=10.0.0"
@@ -907,8 +969,9 @@
     },
     "node_modules/styled-jsx": {
       "version": "5.1.1",
-      "resolved": "https://bendingspoons.jfrog.io/bendingspoons/api/npm/npm/styled-jsx/-/styled-jsx-5.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.1.tgz",
       "integrity": "sha512-pW7uC1l4mBZ8ugbiZrcIsiIvVx1UmTfw7UkC3Um2tmfUq9Bhk8IiyEIPl6F8agHgjzku6j0xQEZbfA5uSgSaCw==",
+      "license": "MIT",
       "dependencies": {
         "client-only": "0.0.1"
       },
@@ -929,7 +992,7 @@
     },
     "node_modules/swiper": {
       "version": "12.0.3",
-      "resolved": "https://bendingspoons.jfrog.io/bendingspoons/api/npm/npm/swiper/-/swiper-12.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/swiper/-/swiper-12.0.3.tgz",
       "integrity": "sha512-BHd6U1VPEIksrXlyXjMmRWO0onmdNPaTAFduzqR3pgjvi7KfmUCAm/0cj49u2D7B0zNjMw02TSeXfinC1hDCXg==",
       "funding": [
         {
@@ -941,15 +1004,17 @@
           "url": "http://opencollective.com/swiper"
         }
       ],
+      "license": "MIT",
       "engines": {
         "node": ">= 4.7.0"
       }
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
-      "resolved": "https://bendingspoons.jfrog.io/bendingspoons/api/npm/npm/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "is-number": "^7.0.0"
@@ -960,14 +1025,16 @@
     },
     "node_modules/tslib": {
       "version": "2.8.1",
-      "resolved": "https://bendingspoons.jfrog.io/bendingspoons/api/npm/npm/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/typescript": {
       "version": "5.9.3",
-      "resolved": "https://bendingspoons.jfrog.io/bendingspoons/api/npm/npm/typescript/-/typescript-5.9.3.tgz",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -978,9 +1045,10 @@
     },
     "node_modules/undici-types": {
       "version": "6.21.0",
-      "resolved": "https://bendingspoons.jfrog.io/bendingspoons/api/npm/npm/undici-types/-/undici-types-6.21.0.tgz",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     }
   }
 }

--- a/src/context/ThemeContext.tsx
+++ b/src/context/ThemeContext.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { createContext, useContext, useEffect, useState, ReactNode } from 'react';
+import { createContext, useContext, useEffect, useState, ReactNode, useCallback } from 'react';
 
 interface ThemeContextType {
   isDarkTheme: boolean;
@@ -8,35 +8,60 @@ interface ThemeContextType {
 
 const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
 
+const STORAGE_KEY = 'theme-preference';
+
 export function ThemeProvider({ children }: { children: ReactNode }) {
   const [isDarkTheme, setIsDarkTheme] = useState(false);
-  const [isInitialized, setIsInitialized] = useState(false);
 
-  useEffect(() => {
-    const stored = localStorage.getItem('dark-theme-enabled');
-    if (stored === 'true') {
-      setIsDarkTheme(true);
+  const applyTheme = useCallback((dark: boolean) => {
+    setIsDarkTheme(dark);
+    if (dark) {
       document.body.classList.add('dark-theme');
+    } else {
+      document.body.classList.remove('dark-theme');
     }
-    setIsInitialized(true);
+    // Update meta tags for browser chrome
+    const metaThemeColor = document.querySelector('meta[name="theme-color"]');
+    if (metaThemeColor) {
+      metaThemeColor.setAttribute('content', dark ? '#121212' : '#ffffff');
+    }
+    const metaColorScheme = document.querySelector('meta[name="color-scheme"]');
+    if (metaColorScheme) {
+      metaColorScheme.setAttribute('content', dark ? 'dark' : 'light');
+    }
   }, []);
 
+  useEffect(() => {
+    // Check for stored user preference first
+    const stored = localStorage.getItem(STORAGE_KEY);
+
+    if (stored !== null) {
+      // User has explicitly set a preference
+      applyTheme(stored === 'dark');
+    } else {
+      // Fall back to system preference
+      const systemPrefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+      applyTheme(systemPrefersDark);
+    }
+
+    // Listen for system preference changes (only applies if no stored preference)
+    const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+    const handleChange = (e: MediaQueryListEvent) => {
+      // Only follow system if user hasn't set explicit preference
+      if (localStorage.getItem(STORAGE_KEY) === null) {
+        applyTheme(e.matches);
+      }
+    };
+
+    mediaQuery.addEventListener('change', handleChange);
+    return () => mediaQuery.removeEventListener('change', handleChange);
+  }, [applyTheme]);
+
   const toggleTheme = () => {
-    setIsDarkTheme(prev => {
-      const newValue = !prev;
-      localStorage.setItem('dark-theme-enabled', String(newValue));
-      if (newValue) {
-        document.body.classList.add('dark-theme');
-      } else {
-        document.body.classList.remove('dark-theme');
-      }
-      // Update theme-color meta tag
-      const metaThemeColor = document.querySelector('meta[name="theme-color"]');
-      if (metaThemeColor) {
-        metaThemeColor.setAttribute('content', newValue ? '#121212' : '#ffffff');
-      }
-      return newValue;
-    });
+    const newValue = !isDarkTheme;
+    // Store explicit user preference
+    localStorage.setItem(STORAGE_KEY, newValue ? 'dark' : 'light');
+    applyTheme(newValue);
   };
 
   return (

--- a/src/context/ThemeContext.tsx
+++ b/src/context/ThemeContext.tsx
@@ -44,13 +44,11 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
       applyTheme(systemPrefersDark);
     }
 
-    // Listen for system preference changes (only applies if no stored preference)
+    // Listen for system preference changes - always follow and clear any override
     const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
     const handleChange = (e: MediaQueryListEvent) => {
-      // Only follow system if user hasn't set explicit preference
-      if (localStorage.getItem(STORAGE_KEY) === null) {
-        applyTheme(e.matches);
-      }
+      localStorage.removeItem(STORAGE_KEY);
+      applyTheme(e.matches);
     };
 
     mediaQuery.addEventListener('change', handleChange);

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -13,15 +13,21 @@ export default function Document() {
         <meta name="apple-mobile-web-app-title" content="Fabio." />
         <meta name="application-name" content="Fabio." />
         <meta name="msapplication-TileColor" content="#ffffff" />
+        <meta name="theme-color" content="#ffffff" />
+        <meta name="color-scheme" content="light dark" />
 
-        {/* Prevent flash of wrong theme */}
+        {/* Prevent flash of wrong theme - checks stored preference, then system preference */}
         <script
           dangerouslySetInnerHTML={{
             __html: `
               (function() {
                 try {
-                  if (localStorage.getItem('dark-theme-enabled') === 'true') {
+                  var stored = localStorage.getItem('theme-preference');
+                  var isDark = stored === 'dark' || (stored === null && window.matchMedia('(prefers-color-scheme: dark)').matches);
+                  if (isDark) {
                     document.documentElement.classList.add('dark-theme');
+                    document.querySelector('meta[name="theme-color"]')?.setAttribute('content', '#121212');
+                    document.querySelector('meta[name="color-scheme"]')?.setAttribute('content', 'dark');
                   }
                 } catch (e) {}
               })();


### PR DESCRIPTION
## Summary
- Use `prefers-color-scheme` media query to respect OS dark mode preference
- Manual theme toggle temporarily overrides system preference
- Override resets when OS theme changes (follows new system preference)
- Add `color-scheme` meta tag for browser UI elements (scrollbars, inputs)
- Add project-level `.npmrc` to use public npm registry

## Test plan
- [ ] Verify theme follows OS preference by default
- [ ] Toggle theme manually, verify it overrides
- [ ] Change OS theme, verify override is cleared and follows new system preference
- [ ] Verify no flash of wrong theme on page load

🤖 Generated with [Claude Code](https://claude.com/claude-code)